### PR TITLE
Install tomcat-native and let the tomcat group see tomcat logs. 

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,6 +28,13 @@
     - tomcat-native
     - tomcat-admin-webapps
 
+- name: Let the tomcat group see tomcat logs
+  file:
+    path: "/var/log/tomcat"
+    state: directory
+    owner: tomcat
+    group: tomcat
+
 - name: Create fcrepo3 database
   mysql_db:
     login_host: "{{ fedora_db_host }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,6 +25,7 @@
     state: present
   with_items:
     - tomcat
+    - tomcat-native
     - tomcat-admin-webapps
 
 - name: Create fcrepo3 database


### PR DESCRIPTION
- Install tomcat-native 
- Make tomcat logs group readable
## Motivation and Context
- Installing the APR based Apache Tomcat Native library is recommend to improve Tomcat performance 
- Making tomcat logs group readable reduces the motivation to `sudo su`.
## How Has This Been Tested?

Used in vagrant dev for about a week through multiple rebuilds with no apparent issues
