### PR TITLE
Update selinux settings to reflect upstream changes to tomcat policy

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -104,16 +104,24 @@
     semanage fcontext -a -t {{ item.context }} "{{ item.path }}(/.*)?" &&
     restorecon -rv {{ item.path }}
   with_items:
+    - path: "{{ fedora_home }}"
+      context: tomcat_var_lib_t
     - path: "{{ fedora_fs_datastream_store }}"
       context: tomcat_var_lib_t
     - path: "{{ fedora_fs_object_store }}"
-      context: usr_t
+      context: tomcat_var_lib_t
 
 - name: Restart tomcat
   service:
     name: tomcat
     state: restarted
     enabled: yes
+
+- name: Set SELinux booleans for tomcat
+  command: "setsebool -P {{ item }} on"
+  with_items:
+    - tomcat_can_network_connect_db
+    - nis_enabled 
 
 - name: Remove default deny XACML policies
   file:


### PR DESCRIPTION
Set appropriate policies and vars now that SELinux is enforced for tomcat. 
